### PR TITLE
supports list.txt as first param (bugfix)

### DIFF
--- a/jdk9build/src/main/java/jdk/ListPackages.java
+++ b/jdk9build/src/main/java/jdk/ListPackages.java
@@ -139,7 +139,7 @@ public class ListPackages {
      */
     private static boolean addAnalyzer(List<ListPackages> analyzers, Path resource) {
         if (!Files.exists(resource)) {
-            throw new IllegalArgumentException(resource.toString());
+            return false;
         }
         try {
             if (Files.isDirectory(resource)) {


### PR DESCRIPTION
list.txt was implemented  - but due to wrong exception handling not really used